### PR TITLE
Hacky fix for GCC15+ compilation `src/active.c:759:9: error: too many…

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ WARN=-Wall
 
 PTHREAD=-pthread
 
-CCFLAGS=$(DEBUG) $(OPT) $(WARN) $(PTHREAD) -pipe
+CCFLAGS=$(DEBUG) $(OPT) $(WARN) $(PTHREAD) -pipe -std=gnu17
 
 GTKLIB=`pkg-config --cflags --libs gtk+-3.0`
 GIOLIB=`pkg-config --cflags --libs glib-2.0`


### PR DESCRIPTION
… arguments to function 'set_limits_from_pp_table'; expected 0, have 1`

A gcc update probably "broke" it (stopped ignoring the error), or changed the behaviour of `()`