### PR TITLE
Proper compilation fix

### DIFF
--- a/commit.txt
+++ b/commit.txt
@@ -1,5 +1,9 @@
-Hacky fix for GCC15+ compilation 
+Fix compilation with gcc 15+
 
 
-`src/active.c:759:9: error: too many arguments to function 'set_limits_from_pp_table'; expected 0, have 1`
-A gcc update probably "broke" it (stopped ignoring the error), or changed the behaviour of `()`
+`\`\`
+src/active.c:759:9: error: too many arguments to function 'set_limits_from_pp_table'; expected 0, have 1
+`\`\`
+
+
+This seems to have been a copy paste mistake since the function does not use `app_wdgts`

--- a/commit.txt
+++ b/commit.txt
@@ -1,0 +1,5 @@
+Hacky fix for GCC15+ compilation 
+
+
+`src/active.c:759:9: error: too many arguments to function 'set_limits_from_pp_table'; expected 0, have 1`
+A gcc update probably "broke" it (stopped ignoring the error), or changed the behaviour of `()`

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ WARN=-Wall
 
 PTHREAD=-pthread
 
-CCFLAGS=$(DEBUG) $(OPT) $(WARN) $(PTHREAD) -pipe -std=gnu17
+CCFLAGS=$(DEBUG) $(OPT) $(WARN) $(PTHREAD) -pipe
 
 GTKLIB=`pkg-config --cflags --libs gtk+-3.0`
 GIOLIB=`pkg-config --cflags --libs glib-2.0`

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ WARN=-Wall
 
 PTHREAD=-pthread
 
-CCFLAGS=$(DEBUG) $(OPT) $(WARN) $(PTHREAD) -pipe
+CCFLAGS=$(DEBUG) $(OPT) $(WARN) $(PTHREAD) -pipe -std=gnu17
 
 GTKLIB=`pkg-config --cflags --libs gtk+-3.0`
 GIOLIB=`pkg-config --cflags --libs glib-2.0`

--- a/src/active.c
+++ b/src/active.c
@@ -755,7 +755,7 @@ void on_btn_active_clicked(GtkButton *button, app_widgets *app_wdgts) {
   if (set_limits_from_file(defsettingspath) == 1) {
     // default settings exist but are outdated or corrupt, get data from pp table
     printf("No valid default settings, using data from pp_table\n");
-    if (set_limits_from_pp_table(app_wdgts) != 0) {
+    if (set_limits_from_pp_table() != 0) {
       printf("Error getting default limits from pp table\n");
       readerror = 1;
       gtk_text_buffer_set_text(GTK_TEXT_BUFFER(g_text_revealer), "Error getting limits from pp table", -1);


### PR DESCRIPTION
Fix compilation with gcc 15+


`\`\`
src/active.c:759:9: error: too many arguments to function 'set_limits_from_pp_table'; expected 0, have 1
`\`\`


This seems to have been a copy paste mistake since the function does not use `app_wdgts`